### PR TITLE
FOLIO-2923: Drop --no-check-certificate from wget (MitM attack)

### DIFF
--- a/content/en/docs/Getting started/Installation/singleservernocontainers.md
+++ b/content/en/docs/Getting started/Installation/singleservernocontainers.md
@@ -87,7 +87,7 @@ CREATE ROLE foliosu WITH PASSWORD 'folio123' LOGIN SUPERUSER;
 1. Import the FOLIO signing key and add the FOLIO apt repository.
 
 ```
-wget --no-check-certificate --quiet -O - https://folio-repo.bib-bvb.de/repository.gpg | sudo apt-key add -
+wget --quiet -O - https://folio-repo.bib-bvb.de/repository.gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] http://folio-repo.bib-bvb.de/repo folio-bleeding main"
 ```
 


### PR DESCRIPTION
FOLIO is vulnerable to man-in-the-middle attacks when some software
is installed using `wget --no-check-certificate` as this allows
attackers to install malware.

Fix:
Don't use `--no-check-certificate` command line option when running wget.

Note:
wget needs the ca-certificates package to check https server certificates.
This is already installed if this wget in step 2 succeeds:
`wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc`