### PR TITLE
We need Node.js 14 LTS, not latest Node.js 16 LTS.

### DIFF
--- a/content/en/docs/Getting started/Installation/singleserverwithcontainers.md
+++ b/content/en/docs/Getting started/Installation/singleserverwithcontainers.md
@@ -435,10 +435,10 @@ sudo apt -y install yarn
 
 ### Building Stripes
 
-1. Move to NodeJS LTS.
+1. Move to NodeJS 14 LTS.
 
 ```
-sudo n lts
+sudo n 14
 ```
 2. cd into the platform-core repository (or platform-complete, if you chose to install that)
 ```


### PR DESCRIPTION
Node.js 16 became the current active LTS version on 2021-10-26:
https://github.com/nodejs/Release#release-schedule

FOLIO has build failures when using Node.js 16,
therefore we currently cannot use "n lts" but must use "n 14".