### PR TITLE
Test broken link

### DIFF
--- a/content/en/docs/Getting started/Installation/_index.md
+++ b/content/en/docs/Getting started/Installation/_index.md
@@ -27,7 +27,7 @@ You can choose to host and operate FOLIO locally. In this scenario, the installa
 
 One of the goals of FOLIO is extensibility. Libraries and vendors can build on existing apps, or develop new apps that extend the library into areas such as campus ERP, research administration, and more. In addition to the coding and testing tools, a developer will probably want to explore the whole FOLIO system, and would need a local instance. Usually, this is a virtual machine with a single-server deployment of FOLIO.
 
-See [Single server with containers]({{< ref "singleserverwithcontainers.md" >}}) or [Single server without containers]({{< ref "singleservernocontainers.md" >}}) for more information.
+See [Single server with containers]({{< ref "singlesxxxxxxxxxxerverwithcontainers.md" >}}) or [Single server without containers]({{< ref "singleservernocontainers.md" >}}) for more information.
 
 ### Kubernetes
 


### PR DESCRIPTION
This pull request demonstrates how FOLIO's `continuous-integration/website-build` reports a hugo failure due to a broken link on the pull request.

Compare with the GitHub Actions report on https://github.com/julianladisch/docs/pull/2 . I've made #46 to enable it in this repository.