### PR TITLE
DOCS-144: .Path deprecation

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,5 +1,5 @@
-{{ if .Path }}
-{{ $pathFormatted := replace .Path "\\" "/" }}
+{{ if .File }}
+{{ $pathFormatted := replace .File.Path "\\" "/" -}}
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ $gh_subdir := ($.Param "github_subdir") }}
 {{ $gh_project_repo := ($.Param "github_project_repo") }}


### PR DESCRIPTION
Since Hugo 0.92.0 layouts/partials/page-meta-links.html cause this deprecation warning:

```
.Path when the page is backed by a file is deprecated and will be removed
in a future release. We plan to use Path for a canonical source path and you
probably want to check the source is a file. To get the current behaviour,
you can use a construct similar to the one below:

  {{ $path := "" }}
  {{ with .File }}
        {{ $path = .Path }}
  {{ else }}
        {{ $path = .Path }}
  {{ end }}
```

Solution:
Apply the indicated fix, the same as upstream: https://github.com/google/docsy/commit/2b6f6f52325c63354694a7234e7a3bd2fe1dafa7