### PR TITLE
DOCS-145: Deprecated google_news in layouts/partials/head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}


### PR DESCRIPTION
Since Hugo 0.90.0 layouts/partials/head.html causes this deprecation warning:

```
The google_news internal template will be removed in a future release.
Please remove calls to this template.
See https://github.com/gohugoio/hugo/issues/9172 for additional information.
```

Task:
Remove google_news