### PR TITLE
Fix links to current and former release

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -21,8 +21,8 @@ Access one of our demo sites and explore FOLIO features and functionality.
 
 Login: diku_admin / admin
 
-* [Current release](https://folio-kiwi.dev.folio.org)
-* [Previous release](https://folio-juniper.dev.folio.org)
+* [Current release](https://folio-lotus.dev.folio.org)
+* [Previous release](https://folio-kiwi.dev.folio.org)
 
 ### Work with a demo site
 


### PR DESCRIPTION
This is the lotus branch, but the current release is Kiwi -- fixing so current release is lotus and prior release is Kiwi