### PR TITLE
Lotus

### DIFF
--- a/content/en/docs/Access/Check out/checkout.md
+++ b/content/en/docs/Access/Check out/checkout.md
@@ -63,6 +63,8 @@ Note: A patron must first be assigned as a proxy for the borrower in their user 
 
 ## Scanning the item to check out
 
+Make sure you have [looked up the user record prior to scanning items.](#locating-a-patron-in-the-system)
+
 To select the item for check out, scan or enter the barcode of the item and click **Enter**. The item is displayed in the Scan Items area with the **Due date** and **Time** and the total number of items scanned is incremented.
 
 The item due date/time may be sooner or later than expected if a service point is going to be closed when the item would normally be due. The item due date/time may also be sooner than expected if the patron's account is set to expire prior to the expected due date/time.

--- a/content/en/docs/Settings/Settings_circulation/settings_circulation.md
+++ b/content/en/docs/Settings/Settings_circulation/settings_circulation.md
@@ -311,8 +311,7 @@ If you selected **Rolling**, you will see the following fields:
 
 Determine whether you want to allow recalls and/or holds.
 
-All of the fields in this section are optional. Note: If you leave them blank, the policy does not allow recalls or holds.
-
+All of the fields in this section are optional. If you leave them blank, the recall return interval and minimum guaranteed loan period default to zero.
 
 ##### Recalls
 


### PR DESCRIPTION
Clarifying text so that there is one place you can link to in the check out docs that references both check out steps. (It's referenced at the very top, but if you want to jump to a specific place and not read the entire document, there is no place that mentions both steps - user scan, item scan. So this adds that.)