### PR TITLE
FOLIO-3609 include Morning Glory module details

### DIFF
--- a/content/en/docs/Settings/System_software_versions/System_software_versions.md
+++ b/content/en/docs/Settings/System_software_versions/System_software_versions.md
@@ -39,6 +39,7 @@ Look for these modules to find out which FOLIO flower release the system runs. T
 
 | mod-configuration | mod-inventory-storage | mod-login-saml | release |
 | ----- | ------- | ----- | - |
+| 5.8.0 | 24.1.0  | 2.4.9 | [Morning Glory R2-2022-GA](https://github.com/folio-org/platform-complete/blob/R2-2022/install.json) |
 | 5.7.9 | 23.0.5  | 2.4.9 | [Lotus R1-2022-hotfix-3](https://github.com/folio-org/platform-complete/blob/R1-2022-hotfix-3/install.json) |
 | 5.7.9 | 23.0.5  | 2.4.8 | [Lotus R1-2022-hotfix-2](https://github.com/folio-org/platform-complete/blob/R1-2022-hotfix-2/install.json) |
 | 5.7.8 | 23.0.5  | 2.4.5 | [Lotus R1-2022-hotfix-1](https://github.com/folio-org/platform-complete/blob/R1-2022-hotfix-1/install.json) |


### PR DESCRIPTION
Include Morning Glory module versions on the "Settings > Software versions" page.

Refs [FOLIO-3609](https://issues.folio.org/browse/FOLIO-3609)