### PR TITLE
DOCS-220: Loses release menu and search box on browser resize

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -74,8 +74,18 @@
     }
 
     .dropdown {
+        .dropdown-menu, .dropdown-item {
+            background-color: $black;
+            background-image: none;
+        }
+
         a {
-            color: $gray-700;
+            color: $white;
+
+            &:hover, &:focus, &:active {
+                color: $blue;
+                text-decoration: none;
+            }
         }
 
         .nav-link {
@@ -97,8 +107,13 @@
 
     &__toggle {
         line-height: 1;
-        color: $gray-900;
+        color: $white;
         margin: 1rem;
+
+        &:hover, &:focus, &:active {
+            color: $white;
+            background-color: $blue;
+        }
     }
 
     &__search {

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -17,11 +17,13 @@
 				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
 			</li>
 			{{ end }}
+			{{/* At wide screen width: this "d-none d-lg-block" element. At small screen width: "d-block d-lg-none" in sidebar-tree.html */}}
 			{{ if  .Site.Params.versions }}
 			<li class="nav-item dropdown d-none d-lg-block">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
+			{{/* At wide screen width: this "d-none d-lg-block" element. At small screen width: "d-block d-lg-none" in sidebar-tree.html */}}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
 			<li class="nav-item dropdown d-none d-lg-block">
 				{{ partial "navbar-lang-selector.html" . }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -7,8 +7,25 @@
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
+  {{ else }}
+  {{/* With small screen width: this "d-block d-lg-none" element. With wide screen width: "d-none d-lg-block" in navbar.html */}}
+  <div id="content-mobile" class="d-block d-lg-none">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop" class="d-none d-lg-block"></div>
   {{ end }}
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
+    {{/* With small screen width: this "d-block d-lg-none" element. With wide screen width: "d-none d-lg-block" in navbar.html */}}
+    {{ if .Site.Params.versions }}
+    <div class="nav-item dropdown d-block d-lg-none">
+      {{ partial "navbar-version-selector.html" . }}
+    </div>
+    {{ end }}
+    {{/* With small screen width: this "d-block d-lg-none" element. With wide screen width: "d-none d-lg-block" in navbar.html */}}
     {{ if  (gt (len .Site.Home.Translations) 0) }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}


### PR DESCRIPTION
When the screen width is small or the text size is increased (browser settings or browser zoom with `Ctrl +`) docsy moves elements like search box, language selector and release menu from the navigation bar at the top into the menu bar at the left or into the drow-down menu.

However, it currently doesn't work. Changes to sidebar-tree.html are needed to fix the incorrect configuration, and changes to _sidebar-tree.scss are needed to fix the colors.

During code review some changes might be requested. After this PR is merged back-port PRs for the flower release branches will be created.