### PR TITLE
DOCS-293: /metadata/inventory/ broken link with spaces

### DIFF
--- a/content/en/docs/Metadata/Inventory/_index.md
+++ b/content/en/docs/Metadata/Inventory/_index.md
@@ -1048,7 +1048,7 @@ To view an item record, follow these steps:
 
 ## Editing an instance record with underlying MARC
 
-See [Editing a MARC record using quickMARC](quickmarc/#Editing%20a%20MARC%20record%20using%20quickmarc).
+See [Editing a MARC record using quickMARC](quickmarc/#editing-a-marc-record-using-quickmarc).
 
 ## Updating an instance record with underlying MARC using the Overlay source bibliographic record action in FOLIO
 

--- a/content/en/docs/Metadata/Inventory/_index.md
+++ b/content/en/docs/Metadata/Inventory/_index.md
@@ -1048,7 +1048,7 @@ To view an item record, follow these steps:
 
 ## Editing an instance record with underlying MARC
 
-See [Editing a MARC record using quickMARC](quickmarc/#Editing a MARC record using quickmarc).
+See [Editing a MARC record using quickMARC](quickmarc/#Editing%20a%20MARC%20record%20using%20quickmarc).
 
 ## Updating an instance record with underlying MARC using the Overlay source bibliographic record action in FOLIO
 


### PR DESCRIPTION
Need to mask spaces with hyphen in anchor links.