### PR TITLE
Fix date in Receiving page header.

### DIFF
--- a/content/en/docs/Acquisitions/Receiving/_index.md
+++ b/content/en/docs/Acquisitions/Receiving/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Receiving"
 linkTitle: "Receiving"
-date: 2023-04-23
+date: 2023-04-03
 weight: 50
 tags: ["parenttopic"]
 ---


### PR DESCRIPTION
A future date makes the page disappear.
The future date is unintended and a typo.