### PR TITLE
Receiving: correct document date to current rather than future date

### DIFF
--- a/content/en/docs/Acquisitions/Receiving/_index.md
+++ b/content/en/docs/Acquisitions/Receiving/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Receiving"
 linkTitle: "Receiving"
-date: 2023-04-23
+date: 2023-04-18
 weight: 50
 tags: ["parenttopic"]
 ---


### PR DESCRIPTION
Edited document date from "2023-04-23" to "2023-04-18" so the document will appear on the docs site (currently missing because 4-23 is a future date)