### PR TITLE
DOCS-311: Remove discussion board links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -194,11 +194,6 @@ enable = false
 	url = "https://slack-invitation.folio.org/"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
-[[params.links.developer]]
-	name = "Discuss"
-	url = "https://discuss.folio.org/"
-	icon = "fa fa-comment-alt"
-        desc = "Discuss development issues around the project"
 
 #From Arnon
 [[menu.main]]
@@ -213,8 +208,3 @@ enable = false
     url = "https://wiki.folio.org"
     weight = 20
 
-[[menu.main]]
-    identifier = "discussion"
-    name = "Discussion Boards"
-    url = "https://discuss.folio.org"
-    weight = 30


### PR DESCRIPTION
https://discuss.folio.org/ is no longer used.
It is a static snapshot of the website as of February 14, 2023.