### PR TITLE
Access links upate

### DIFF
--- a/content/en/docs/Access/_index.md
+++ b/content/en/docs/Access/_index.md
@@ -14,4 +14,4 @@ In FOLIO, resource access includes essential circulation functions. These functi
 
 ## Circulation Settings
 
-The circulation of library materials is governed by a set of rules and policies.  These rules and policies are defined by the library and implemented in the [Circulation]({{< ref "/settings_circulation.md" >}}) and the [Courses]({{< ref "/settings_courses.md" >}}) areas of the FOLIO Settings app.  
+The circulation of library materials is governed by a set of rules and policies.  These rules and policies are defined by the library and implemented in the [Circulation](../settings/settings_circulation/settings_circulation/) and the [Courses](../settings/settings_courses/settings_courses/) areas of the FOLIO Settings app.  


### PR DESCRIPTION
Replaced 'ref' style links with relative links, to prevent the links jumping to a different release version (when Poppy becomes no longer the main branch). Thanks!