### PR TITLE
Move Glossary to under 'About FOLIO' as the first subitem

### DIFF
--- a/content/en/docs/About FOLIO/Glossary/_index.md
+++ b/content/en/docs/About FOLIO/Glossary/_index.md
@@ -1,7 +1,9 @@
 ---
 title: "Glossary"
 linkTitle: "Glossary"
-weight: 800
+url: docs/glossary
+weight: 5
+tags: ["parenttopic"]
 ---
 
 **This section of the documentation contains links to external sites. Please be advised that these external sites are not maintained by the FOLIO Documentation Group and may be aligned with a different FOLIO release.**


### PR DESCRIPTION
Moving Glossary as decided on https://folio-org.atlassian.net/wiki/spaces/SS/pages/4490535/2024-02-14+Documentation+Working+Group+Agenda+Meeting+Notes

Keep the url to avoid broken links on other sites.