### PR TITLE
Revert "Create databases with UTF-8 and und-x-icu sorting"

### DIFF
--- a/content/en/docs/Getting started/Installation/singleserverfreshinstall.md
+++ b/content/en/docs/Getting started/Installation/singleserverfreshinstall.md
@@ -221,14 +221,14 @@ sudo su -c psql postgres postgres
 2. Create a database role for Okapi and a database to persist Okapi configuration.
 ```
 CREATE ROLE okapi WITH PASSWORD 'okapi25' LOGIN CREATEDB;
-CREATE DATABASE okapi WITH OWNER okapi ENCODING 'UTF-8' LC_COLLATE 'und-x-icu' LC_CTYPE 'und-x-icu' TEMPLATE template0;
+CREATE DATABASE okapi WITH OWNER okapi;
 ```
 
 3. Create a database role and database to persist tenant data.
 
 ```
 CREATE ROLE folio WITH PASSWORD 'folio123' LOGIN SUPERUSER;
-CREATE DATABASE folio WITH OWNER folio ENCODING 'UTF-8' LC_COLLATE 'und-x-icu' LC_CTYPE 'und-x-icu' TEMPLATE template0;
+CREATE DATABASE folio WITH OWNER folio;
 ```
 
 4. Exit psql with **\q** command


### PR DESCRIPTION
This doesn't work with Ubuntu when using PostgreSQL older than 16.

For PostgreSQL 12 it works with Alpine but not with Ubuntu.

This reverts commit 9706bdede990115303410d8887e11d7665982ff9.