### PR TITLE
Quesnelia: Fix broken links in 'Platform essentials'

### DIFF
--- a/content/en/docs/Platform essentials/Permissions/_index.md
+++ b/content/en/docs/Platform essentials/Permissions/_index.md
@@ -69,8 +69,8 @@ A list of permissions will be populated in the window pane on the right. Each pe
 
 Common permissions workflows include:
 
-* [Assigning Permissions and Permissions Sets to a User Record]({{< ref "/users.md#assigning-permissions-to-a-user-record" >}})
-* [Creating Your Own Permission Sets]({{< ref "/Settings_users.md#settings--users--permission-sets" >}})
+* [Assigning Permissions and Permissions Sets to a User Record]({{< ref "users.md#assigning-permissions-to-a-user-record" >}})
+* [Creating Your Own Permission Sets]({{< ref "Settings_users.md#settings--users--permission-sets" >}})
 
 ## Visible versus Invisible permissions
 

--- a/content/en/docs/Platform essentials/_index.md
+++ b/content/en/docs/Platform essentials/_index.md
@@ -7,7 +7,7 @@ weight: 225
 In FOLIO, there are several parts of functionality that support library workflows
 across FOLIO apps. These include:
 
-* [Item status]({{< ref "/itemstatus.md" >}})
-* [Keyboard Shortcuts]({{< ref "/keyboardshortcuts.md" >}})
-* [Locations]({{< ref "/locations.md" >}})
-* [Permissions]({{< ref "/Permissions" >}})
+* [Item status]({{< ref "itemstatus.md" >}})
+* [Keyboard Shortcuts]({{< ref "keyboardshortcuts.md" >}})
+* [Locations]({{< ref "locations.md" >}})
+* [Permissions]({{< ref "Permissions" >}})


### PR DESCRIPTION
The broken links fail the build on recent versions of hugo/docsy:
```
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/itemstatus.md": "/src/content/en/docs/Platform essentials/_index.md:10:17": page not found
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/keyboardshortcuts.md": "/src/content/en/docs/Platform essentials/_index.md:11:24": page not found
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/locations.md": "/src/content/en/docs/Platform essentials/_index.md:12:15": page not found
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/Permissions": "/src/content/en/docs/Platform essentials/_index.md:13:17": page not found
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/users.md": "/src/content/en/docs/Platform essentials/Permissions/_index.md:72:65": page not found
site_1  | ERROR [en] REF_NOT_FOUND: Ref "/Settings_users.md": "/src/content/en/docs/Platform essentials/Permissions/_index.md:73:39": page not found
```