### PR TITLE
Ramsons requests

### DIFF
--- a/content/en/docs/Access/Requests/requests.md
+++ b/content/en/docs/Access/Requests/requests.md
@@ -319,7 +319,7 @@ To print pick slips, in the Requests pane, select **Actions > Print pick slips f
 3. Select **Actions > Print selected pick slips for [your service point].** A print dialog appears.
 
 #### Printing a single pick slip
-1. 	In the Search & filter pane, select **Request type > Pages** and **Request status > Open - Not yet filled** to filter the items down to open page requests.
+1. In the Search & filter pane, select **Request type > Pages** and **Request status > Open - Not yet filled** to filter the items down to open page requests.
 2. Have the **Single print** column selected in the Actions menu.
 3. Click the **Print** button in the Single print column. A print dialog appears. Note: the print button will only be active for items whose effective locations are associated with your selected service point.
 

--- a/content/en/docs/Access/Requests/requests.md
+++ b/content/en/docs/Access/Requests/requests.md
@@ -117,13 +117,9 @@ You can only edit open requests. Once a request is closed, it cannot be edited.
 You can duplicate open requests but you will need to change either the requester or the item in order to save the request, as there cannot be two requests on the same item by the same requester. Closed requests can be duplicated, but you will need to enter a requester barcode.
 
 1. [Find the request you want to duplicate.](#searching-for-requests) 
-
 2. In the **Request details** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
-
-3. Edit any of the request information before submitting the request.
-
+3. Edit the request.
 4. Select a **Pickup service point**.
-
 5. Click **Save & close**. The new request appears in the Request details pane.
 
 ### Moving an item-level request to another item on the same instance
@@ -225,13 +221,9 @@ You can only edit open requests. Once a request is closed, it cannot be edited.
 You can duplicate any open title level request. When you duplicate the request, you will need to change the instance or the requester, because a patron cannot have more than one open title level request on the same instance. 
 
 1. [Find the request you wish to duplicate.](#searching-for-requests) 
-
 2. In the **Request details** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
-
-3. Edit any of the request information before submitting the request.
-
+3. Edit the request.
 4. Select a **Pickup service point**.
-
 5. Click **Save & close**. The new request appears in the Request details pane.
 
 ### Reordering Request Queues with Title Level Requests
@@ -322,7 +314,7 @@ You can configure the information that appears on the pick slips in the [Setting
 To print pick slips, in the Requests pane, select **Actions > Print pick slips for [your service point]**. A print dialog appears.
 
 #### Printing selected pick slips 
-1. In the Search & filter pane, select **Request type > Pages and Request status > Open - Not yet filled** to filter the items down to open page requests.
+1. In the Search & filter pane, select **Request type > Pages** and **Request status > Open - Not yet filled** to filter the items down to open page requests.
 2. Select the checkboxes in the first column of the requests you want to print. You can only print Page requests for items whose effective locations are associated with your selected service point.
 3. Select **Actions > Print selected pick slips for [your service point].** A print dialog appears.
 

--- a/content/en/docs/Access/Requests/requests.md
+++ b/content/en/docs/Access/Requests/requests.md
@@ -5,7 +5,7 @@ date: 2022-11-10
 weight: 50
 ---
 
-The Requests app allows you to create and manage requests. 
+The Requests app allows you to create and manage requests.
 
 FOLIO supports two kinds of requests - item level, and title level. 
 
@@ -70,7 +70,7 @@ Closed requests have one of the following statuses:
 
 To search for requests, enter your search terms into the box on the **Search & filter** pane. You can keyword search by title, or "starts with" search by item barcode, requester barcode, or item call number.
 
-You can also use the Request type, Request status, Request level, Tags, and Pickup service point filters to find requests or further limit your search.
+You can also use the Request type, Request status, Request level, Tags, Pickup service point, and Print status filters to find requests or further limit your search. The [Settings > Circulation > View print details](../../../settings/settings_circulation/settings_circulation/#settings--circulation--view-print-details) option needs to be selected for the Print status filter to be visible.
 
 You can choose which columns appear in your search results by clicking on the Actions menu. Under Show columns, you can check or uncheck columns to change what you see in the results pane.
 
@@ -101,14 +101,14 @@ Requesting is controlled by circulation rules and item statuses. You cannot requ
 8. Optional: Enter any **Patron comments.** For example, if the patron needs the item immediately, you can note it here. Patron comments show up in the CSV report and can be included in pick slips.
 9. Select the **Fulfillment preference**.
 10. Select the **Pickup service point** or **Delivery address**, depending on your selection in the previous step.
-11. Click **Save & close**. The request is saved and the Request Detail pane appears. The patron receives an email notification saying their request was received by the library, [if you have this notification configured.](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies)
+11. Click **Save & close**. The request is saved and the Request details pane appears. The patron receives an email notification saying their request was received by the library, [if you have this notification configured.](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies)
 
 ### Editing an item level request
 
 You can only edit open requests. Once a request is closed, it cannot be edited.
 
 1. [Find the request you want to edit.](#searching-for-requests) 
-2. In the **Request Detail** pane, select **Actions > Edit.**
+2. In the **Request details** pane, select **Actions > Edit.**
 3. Edit the request.
 4. Click **Save & close**. The request is updated.
 
@@ -118,13 +118,13 @@ You can duplicate open requests but you will need to change either the requester
 
 1. [Find the request you want to duplicate.](#searching-for-requests) 
 
-2. In the **Request Detail** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
+2. In the **Request details** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
 
 3. Edit any of the request information before submitting the request.
 
 4. Select a **Pickup service point**.
 
-5. Click **Save & close**. The new request appears in the Request Detail pane.
+5. Click **Save & close**. The new request appears in the Request details pane.
 
 ### Moving an item-level request to another item on the same instance
 
@@ -133,7 +133,7 @@ You can move a request from one item to another on the same instance. You may wa
 Note: If a recall request is moved to a loan item that wasn’t previously recalled, the loan will be recalled--the patron gets a recall notice, [if configured,](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies) and the loan’s due date may be truncated or extended, depending on the associated loan policy.
 
 1. [Find the request you want to move.](#searching-for-requests)
-2. In the **Request Detail** pane, select **Actions > Move request**.
+2. In the **Request details** pane, select **Actions > Move request**.
 3. In the **Select item** window, select the item you want to move the request to.
 4. If the current request type is not allowed you will need to choose an allowed type in the **Select request type** dialog and click **Confirm** to allow the request to be converted.
 
@@ -142,7 +142,7 @@ Note: If a recall request is moved to a loan item that wasn’t previously recal
 You can change a patron’s location in the request queue for an item by reordering the queue.
 
 1. [Find the request with the queue you want to reorder.](#searching-for-requests)
-2. In the **Request Detail** pane, select **Actions > Reorder queue**.
+2. In the **Request details** pane, select **Actions > Reorder queue**.
 3. In the **Request queue** window, reorder the requests by dragging them into their new positions. Requests cannot be moved above Page requests, even if fulfillment has not begun.
 4. Once you are done moving the requests, click the **X** to exit the Request queue window. The revised queue order is saved.
 
@@ -157,7 +157,7 @@ Note: When cancelling a request, you should consider the following:
 * If you cancel a requested item that is awaiting pickup, it appears on the [Hold shelf clearance report](#exporting-a-hold-shelf-clearance-report).
 
 1. [Find the request you want to cancel.](#searching-for-requests)
-2. In the **Request Detail** pane, select **Actions > Cancel request**.
+2. In the **Request details** pane, select **Actions > Cancel request**.
 3. In the **Confirm request cancellation** dialog, select the **Reason for cancellation**.
 4. Optional: Enter any additional notes on the cancellation in the **Additional information for patron** box. If you selected **Other** as the reason, then you must supply additional information.
 5. Click **Confirm**. The dialog closes and the request is cancelled. The Request status is updated to Closed - Cancelled and the patron receives a cancellation notification email, [if you have this notification configured.](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies)
@@ -185,7 +185,7 @@ Note: You must have permission to create requests in the Requests app in order t
 8. Optional: Enter any **Patron comments**. For example, if the patron needs the item immediately, you can note it here. Patron comments show up in the CSV report and can be included in pick slips.
 9. Select the **Fulfillment preference**.
 10. Select the **Pickup service point** or **Delivery address**, depending on your selection in the previous step.
-11. Click **Save & close**. The request is saved and the Request Detail pane appears. The patron receives an email notification saying their request was received by the library, [if you have this notification configured](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies).
+11. Click **Save & close**. The request is saved and the Request details pane appears. The patron receives an email notification saying their request was received by the library, [if you have this notification configured](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies).
 
 ### How FOLIO decides which item will fill a title-level request
 
@@ -216,7 +216,7 @@ For recalls, the item information indicates the item that was recalled, but when
 You can only edit open requests. Once a request is closed, it cannot be edited.
 
 1. [Find the request you want to edit.](#searching-for-requests) 
-2. In the **Request Detail** pane, select **Actions > Edit.**
+2. In the **Request details** pane, select **Actions > Edit.**
 3. Edit the request.
 4. Click **Save & close**. The request is updated.
 
@@ -226,13 +226,13 @@ You can duplicate any open title level request. When you duplicate the request, 
 
 1. [Find the request you wish to duplicate.](#searching-for-requests) 
 
-2. In the **Request Detail** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
+2. In the **Request details** pane, select **Actions > Duplicate**. A New request window appears with the same Item information, Requester information, and Request information as the request you chose to duplicate.
 
 3. Edit any of the request information before submitting the request.
 
 4. Select a **Pickup service point**.
 
-5. Click **Save & close**. The new request appears in the Request Detail pane.
+5. Click **Save & close**. The new request appears in the Request details pane.
 
 ### Reordering Request Queues with Title Level Requests
 
@@ -267,7 +267,7 @@ Before you cancel a request, consider:
 * If there are other open title level requests on the instance that are not in progress, the item needs to be checked in to fulfill the next request in the queue.
 
 1. [Find the request you want to cancel.](#searching-for-requests) 
-2. In the **Request Detail** pane, select **Actions > Cancel request**.
+2. In the **Request details** pane, select **Actions > Cancel request**.
 3. In the **Confirm request cancellation** dialog, select the **Reason for cancellation**.
 4. Optional: Enter any additional notes on the cancellation in the **Additional information for patron** box. If you selected **Other** as the reason, then you must supply additional information.
 5. Click **Confirm**. The dialog closes and the request is canceled. The Request status is updated to Closed - Canceled and the patron receives a cancellation notification email, [if that option is configured](../../../settings/settings_circulation/settings_circulation/#patron-notice-policies).
@@ -313,16 +313,37 @@ To create a pick report, follow these steps:
 
 ### Printing pick slips
 
+#### Printing all pick slips for a service point
+
 The pick slips report generates a single slip for every paged item that needs to be pulled from the shelf. Because this report automatically prints only those items whose Effective location is associated with the currently selected service point, you must be signed in to the service point you want to generate the slips for. If no items match the report’s criteria, the option is grayed out.
 
 You can configure the information that appears on the pick slips in the [Settings app.](../../../settings/settings_circulation/settings_circulation/#settings--circulation--staff-slips)
 
 To print pick slips, in the Requests pane, select **Actions > Print pick slips for [your service point]**. A print dialog appears.
 
+#### Printing selected pick slips 
+1. In the Search & filter pane, select **Request type > Pages and Request status > Open - Not yet filled** to filter the items down to open page requests.
+2. Select the checkboxes in the first column of the requests you want to print. You can only print Page requests for items whose effective locations are associated with your selected service point.
+3. Select **Actions > Print selected pick slips for [your service point].** A print dialog appears.
+
+#### Printing a single pick slip
+1. 	In the Search & filter pane, select **Request type > Pages** and **Request status > Open - Not yet filled** to filter the items down to open page requests.
+2. Have the **Single print** column selected in the Actions menu.
+3. Click the **Print** button in the Single print column. A print dialog appears. Note: the print button will only be active for items whose effective locations are associated with your selected service point.
+
+#### Showing the pick slip print history
+
+To select the search result columns **# Copies** or **Printed** you need to choose the option Settings > Circulation > Requests > View print details > Enable view print details (Pick slips).
+
+**# Copies** shows the number of times the request pick slip has been printed.
+
+**Printed** shows the username and date/time for the most recent printing.
+
+   
 ## Printing Hold request search slips  
 Libraries can choose to use search slips if they have many copies of a title (instance), but not all copies have been cataloged. When a patron requests an item from that instance, a search slip can be printed so a staff member can look for the item. Libraries must enable **Allow print hold requests (Open - Not yet filled)** in [Settings > Circulation > Print hold requests](../../../settings/settings_circulation/settings_circulation/#settings--circulation--print-hold-requests) in order to use this feature.
 
-The search slips report generates a single slip for every item level hold request with request status **Open - Not yet filled**. The report only prints hold requests for items that are shelved nearest the currently selected service point (i.e., those items whose Effective location is associated with the currently selected service point). You must be signed in to the service point you want to generate the search slips for. If no items match the report’s criteria, the option is grayed out.
+The search slips report generates a single slip for every hold request with request status **Open - Not yet filled**. The report only prints hold requests for items that are shelved nearest the currently selected service point (i.e., those items whose Effective location is associated with the currently selected service point). You must be signed in to the service point you want to generate the search slips for. If no items match the report’s criteria, the option is grayed out.
 
 You can configure the information that appears on the pick slips in the [Settings app](../../../settings/settings_circulation/settings_circulation/#configuring-a-staff-slip).
 
@@ -333,7 +354,7 @@ To print search slips, in the Requests pane, select Actions > Print search slips
 You can add a tag to any open request. Tags are included in the [CSV export report](#exporting-your-search-results-to-csv), in case you want to use them for your workflow. For example, you can tag requests that were not found.
 
 1. [Find the request you want to tag.](#searching-for-requests)
-2. In the **Request Detail** pane, click the **tag icon**.
+2. In the **Request details** pane, click the **tag icon**.
 3. In the **Tag** pane, either select a tag from the box or enter a tag.
 4. Click the **X** on the Tag window to close the pane and save the tag. The tag number updates to the number of tags applied to the request.
 


### PR DESCRIPTION
Added single/select/history sections. Edited for Hold slips now available for TLRs. Changed to reflect Request Detail pane now Request details. Wording changes for simplicity / less ambiguity.
(DOCS-433, DOCS-459; DOCS-460; DOCS-466. [Note that the link to View print details in Settings links to a section of documentation not yet done