### PR TITLE
Add proxy_cookie_path to path based proxy snippet for nginx

### DIFF
--- a/content/en/docs/Getting started/Installation/hostnames.md
+++ b/content/en/docs/Getting started/Installation/hostnames.md
@@ -30,6 +30,8 @@ Disadvantages:
 ```
         # WARNING: location requires a trailing slash
         location /okapi/ {
+                # WARNING: proxy_cookie_path requires a trailing slash
+                proxy_cookie_path / /okapi/;
                 # WARNING: proxy_pass requires a trailing slash
                 proxy_pass http://127.0.0.1:9130/;
                 proxy_redirect default;


### PR DESCRIPTION
Without the proxy_cookie_path calling the refresh API is rejected by the browser because of wrong path in the cookie.