### PR TITLE
Update Ramsons settings_circulation

### DIFF
--- a/content/en/docs/Settings/Settings_circulation/settings_circulation.md
+++ b/content/en/docs/Settings/Settings_circulation/settings_circulation.md
@@ -154,7 +154,7 @@ Staff slips have eight categories of tokens, listed in the table below. All of t
 |     Borrower                 |     Due date receipt                                                                          |     Hold, Pick slip, Request delivery, Search slip (Hold requests),Transit   |
 |     Loan                     |     Due date receipt                                                                          |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit  |
 |     Request                  |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit                   |     Due date receipt                                                         |
-|     Request delivery address |     Request delivery, Pick slip                                                                         |     Due date receipt, Hold, Search slip (Hold requests), Transit  |
+|     Request delivery address |     Request delivery, Pick slip, Search slip (Hold requests)                                                                         |     Due date receipt, Hold, Transit  |
 |     Requester                |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit                   |     Due date receipt                                                         |
 
 Note: *StaffSlip.staffUsername* only populates for Pick slip. *Request.barcodeImage* only populates for Pick slip and Search slip (Hold requests).

--- a/content/en/docs/Settings/Settings_circulation/settings_circulation.md
+++ b/content/en/docs/Settings/Settings_circulation/settings_circulation.md
@@ -154,7 +154,7 @@ Staff slips have eight categories of tokens, listed in the table below. All of t
 |     Borrower                 |     Due date receipt                                                                          |     Hold, Pick slip, Request delivery, Search slip (Hold requests),Transit   |
 |     Loan                     |     Due date receipt                                                                          |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit  |
 |     Request                  |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit                   |     Due date receipt                                                         |
-|     Request delivery address |     Request delivery                                                                          |     Due date receipt, Hold, Pick slip, Search slip (Hold requests), Transit  |
+|     Request delivery address |     Request delivery, Pick slip                                                                         |     Due date receipt, Hold, Search slip (Hold requests), Transit  |
 |     Requester                |     Hold, Pick slip, Request delivery, Search slip (Hold requests), Transit                   |     Due date receipt                                                         |
 
 Note: *StaffSlip.staffUsername* only populates for Pick slip. *Request.barcodeImage* only populates for Pick slip and Search slip (Hold requests).


### PR DESCRIPTION
Corrected error. Request delivery address tokens do populate for Pick slip -- if they are not empty.