### PR TITLE
Trillium platform essentials permissions

### DIFF
--- a/content/en/docs/Platform essentials/Permissions/_index.md
+++ b/content/en/docs/Platform essentials/Permissions/_index.md
@@ -6,16 +6,16 @@ weight: 50
 tags: ["parenttopic"]
 ---
 
-FOLIO has a user permissions system that allows for granular control over what users can access in their FOLIO installation.
+FOLIO has a user role system that allows for granular control over what users can access in their FOLIO installation.
 
-Each app defines its own permissions for the frontend and backend modules that it uses.
+Each app defines its own capabilities for the frontend and backend modules that it uses.
 
-By default, a FOLIO installation does not provide roles or permission profiles for library staff. Instead, FOLIO administrators can build their own groups of permissions called permission sets that correspond to their local needs. They can then assign those permissions to users through the Users app.
+By default, a FOLIO installation does not provide roles or permission profiles for library staff. Instead, FOLIO administrators can build their own groups of roles that correspond to their local needs. They can then assign those roles to users through the Users app.
 
 ## Managing Roles with Eureka
 
 ## Overview
-The new Eureka platform, which FOLIO is adopting with the Sunflower release, replaces the permission-based access control model with a roles-based permission model. This page
+The new Eureka platform, which FOLIO is adopting with the Sunflower release, replaces the permission-based access control model from previous releases with a roles-based permission model. This page
 explains how to manage roles and their assignments. Information on migrating permissions from the Okapi platform to Eureka can be found at the bottom of the page. 
 
 ## Terminology 
@@ -110,7 +110,7 @@ Use the "**Actions**" menu in the role details pane to select "**Edit**" to alth
 The role edit form looks and behaves the same as the role creation form. Refer to the Role Creation section for details.  
 
 ## Role Deletion 
-Deletion of a role is similar to role modification. Refer to the Role Modification section for details. When delting a role, instead of selecting "**Edit**" from the "**Actions**" menu, select "**Delete**." Exercise caution when deleting roles: **deleting a role cannot be undone.** When deleting a role which is assigned to users, the role assignments will automatically be removed from those users. If you are sure you wish to delete the role, you will be asked to confirm. 
+Deletion of a role is similar to role modification. Refer to the Role Modification section for details. To delete a role, from the "**Actions**" menu, select "**Delete**." Exercise caution when deleting roles: **deleting a role cannot be undone.** When deleting a role which is assigned to users, the role assignments will automatically be removed from those users. If you are sure you wish to delete the role, you will be asked to confirm. 
 
 
 ## Role Duplication 
@@ -177,7 +177,7 @@ To manage role assignments in the context of a particular user, navigate to the 
 
 
 
-Select a user to display that user's details in a separate pane. Here yo uwill see a "User roles" accordion (collapsed by default). When collapsed, a bubble in the accordion header indicates how many roles the user is presently assigned to. While this accordion is helpful for viewing a user's role assignments, you cannot edit a user's role assignments here. Instead, you must select the "**Edit**" option from the "**Action**" menu. 
+Select a user to display that user's details in a separate pane. Here you will see a "User roles" accordion (collapsed by default). When collapsed, a bubble in the accordion header indicates how many roles the user is presently assigned to. While this accordion is helpful for viewing a user's role assignments, you cannot edit a user's role assignments here. Instead, you must select the "**Edit**" option from the "**Action**" menu. 
 
 
 

--- a/content/en/docs/Platform essentials/Permissions/_index.md
+++ b/content/en/docs/Platform essentials/Permissions/_index.md
@@ -74,19 +74,14 @@ This diagram may help you visualize the relationships between some of these term
 ![image](relation-diagram.png)
 
 ## Role Creation
-Role creation happens in the "**Authorization Roles**" section of **Settings**. Use the "**+New**" button to open the form for creating a role. 
+Role creation happens in the "**Authorization Roles**" section of **Settings**. Use the "**+New**" button in the upper right corner to open the form for creating a role. 
 
-![image](role-creation-1.png)
 
 Provide a name and description, then use the "**Select application**" button to open the selection modal. The purpose of selecting applications is to specify the functional areas which provide capabilities and capability sets you want to add to the role. Only Capabilities and Capability Sets provided by the selected application(s) will be shown. 
 
-![image](role-creation-2.png)
-
-![image](role-creation-3.png)
 
 After selecting one or more applications and clicking "**Save and close**," the Capability and Capability Set portions of the role creation form will be populated, and you can select those which you want to include in your role by checking individual boxes or the boxes in the column headers. 
 
-![image](role-creation-4.png)
 
 #### Notes on selecting Capabilities and Capability Sets: 
 * Capabilities and Capability Sets are divided into 3 groups: **Data**, **Settings**, and **Procedural**. These are intended to make it easier to sort through the options. Here are brief descriptions of each set: 
@@ -100,48 +95,43 @@ After selecting one or more applications and clicking "**Save and close**," the 
 * ***Tip:*** Using "find on page" (e.g. `Ctrl+F` / `Cmnd+F`) can be helpful when searching for capabilities
 * Don't forget to click "**Save & close**" when you've made your selections
 
-![image](role-creation-5.png)
+
 
 ## Role Modification
 Making adjustments to roles is very similar to creating new roles. Start by selecting the name of the desired role. This will result in a detail pane to be displayed. 
 
 ***Tip***: the search bar can help you find what you're looking for. 
 
-![image](role-modification-1.png)
 
-Use the "**Actions**" menu in the role details pane to edit the role. 
+Use the "**Actions**" menu in the role details pane to select "**Edit**" to alther the role. 
 
-![image](role-modification-2.png)
+ 
 
 The role edit form looks and behaves the same as the role creation form. Refer to the Role Creation section for details.  
 
 ## Role Deletion 
 Deletion of a role is similar to role modification. Refer to the Role Modification section for details. When delting a role, instead of selecting "**Edit**" from the "**Actions**" menu, select "**Delete**." Exercise caution when deleting roles: **deleting a role cannot be undone.** When deleting a role which is assigned to users, the role assignments will automatically be removed from those users. If you are sure you wish to delete the role, you will be asked to confirm. 
 
-![image](role-deletion-1.png)
 
 ## Role Duplication 
 Duplication of a role can be accomplished by following similar steps as role modification. Refer to the Role Modification section for details. However, instead of selecting "**Edit**" from the "**Actions**" menu, select "**Duplicate**." You will be asked to confirm. A system generated name will be given to the duplicate role. Role assignments will not be copied to the new role. 
 
-![image](role-duplication-1.png)
 
 After confirming you will automatically be taken to the new/duplicate role. 
 
-![image](role-duplication-2.png)
+
 
 ## Shared Roles
 Shared roles are centrally managed in that they can only be edited in the consortia manager. A shared role will appear as a Role in all tenants with the same capabilities. User from the given tenant can be assigned to that role. Editing that role in the central tenant will change it for all tenants. 
 
 To share a role users must have permissions to access the consortia manager app and share data. With your active affiliation set to the systems central tenant. Navigate to Consortia manager -> Authorization Roles. 
 
-![image](shared-roles-1.png)
 
 * Select the central tenant from the Member dropdown at the top of the second pane 
 * Choose a Role that you have created in the central tenant 
 * Click the actions menu
 * Click "Share to all" 
 
-![image](shared-roles-2.png)
 
 * When the confirmation modal appears click "Submit" to confirm and share the role with all tenants in the system 
 * You will see a success toast message 
@@ -163,56 +153,55 @@ To manage role assignments in the context of a particular role, navigate to the 
 
 ***Tip:*** the search bar can help you find what you're looking for.
 
-![image](auth-1.png)
 
 Once you have selected a role, an additional pane will open showing the details of that role. This role detail pane will include on "**Assigned users**" accordion (which should be expanded by default). 
 
-![image](auth-2.png)
+
 
 Clicking on the "**Assign/Unassign**" button will open the "**Select User**" modal. Use the facets and search functions to help find the user(s) you want to assign or unassign. 
 
-![image](auth-3.png)
+
 
 To assign a user to the role, check the box in the first column. To unassign a user from the role, uncheck that box. When finished, click "**Save.**"
 
-![image](auth-4.png)
+
 
 In some cases you may see a dialogue asking you to confirm the creation of user records in Keycloak. The creation of these records is necessary for the role assignment to succeed. Click "**Confirm**" to proceed, or "**Cancel**" if you're unsure. 
 
-![image](auth-5.png)
+
 
 Upon completion, you will land back at the role detail view. If the assignment (for unassignment) was successful, you should see a green message indicating the success at the bottom of your screen. The "**Assigned users**" accordion should be updated to reflect the changes you've just made. 
 
 ### Users App
 To manage role assignments in the context of a particular user, navigate to the "**Users**" app. Use the facets and search functions to help find the user you want to assign to roles. 
 
-![image](users-1.png)
+
 
 Select a user to display that user's details in a separate pane. Here yo uwill see a "User roles" accordion (collapsed by default). When collapsed, a bubble in the accordion header indicates how many roles the user is presently assigned to. While this accordion is helpful for viewing a user's role assignments, you cannot edit a user's role assignments here. Instead, you must select the "**Edit**" option from the "**Action**" menu. 
 
-![image](users-2.png)
+
 
 On the Edit form, scroll down to and click on the "User roles" accordion to expand it. Here you will see the list of roles this user is assigned to. You can click the "X" icon for a given role to unassign that role. You also have the option to unassign all user roles and add user roles via the buttons below the list or roles. 
 
-![image](users-3.png)
+
 
 When using "Unassign all users roles," you will be prompted to confirm. The roles being removed will be listed in the dialogue box. 
 
-![image](users-4.png)
+
 
 When using "Add user roles," the "Select user roles" modal will be displayed. Use the facets and search functions to help find the role(s) you want to assign to the user. Check the boxes next to the roles you want to assign (or uncheck the roles you want to unassign). When finished, click "**Save & close**" to submit your changes. 
 
-![image](users-5.png)
+
 
 Finally, in order for any of the changes you've made to be saved, you must click the "**Save & close**" button in the user edit form. 
 
-![image](users-6.png)
+
 
 ***N.B.*** Don't forget to click "Save & close" on the user edit form to save your changes. If you cancel now, your changes will not take effect. 
 
 In some cases you may see a dialgoue asking you to confirm the creation of a user record in Keycloak. The creation of this record is necessary for the role assignment to succeed. Click "**Confirm**" to proceed, or "**Cancel**" if you're unsure. 
 
-![image](users-7.png)
+
 
 Upon completion, you will land back at the user detail view. The "**User roles**" accordion shouild be updated to reflect the changes you've just made. 
 


### PR DESCRIPTION
removed images from platform essentials to support automatic translation; added more emphasis to roles in intro