### PR TITLE
Rename 'Consortia manager' to 'Consortium manager' (Sunflower)

### DIFF
--- a/content/en/docs/Consortia/_index.md
+++ b/content/en/docs/Consortia/_index.md
@@ -44,9 +44,9 @@ The following are the permissions for Consortium manager:
 * **Consortia API module - all permissions.** This permission allows the user to use the Consortia API module to add or remove members in Consortium manager. 
 * **Consortia: Assign and unassign affiliations.** This permission allows the user to add or remove affiliations of other users.
 * **Consortia: View affiliations.** This permission allows the user to view the affiliations of other users.
-* **Consortium manager: Can create, edit and remove settings.** This permission allows the user to perform build, create, edit and delete actions via the Consortia manager BUT the user must have the correct permissions in individual tenants to carry out these actions.
+* **Consortium manager: Can create, edit and remove settings.** This permission allows the user to perform build, create, edit and delete actions via the Consortium manager BUT the user must have the correct permissions in individual tenants to carry out these actions.
 * **Consortium manager: Can share settings to all members.** This permission allows a user to create settings that will be shared by all members and is only editable in the central tenant.
-* **Consortium manager: Can view existing settings.** This permission allows a user to view all the settings of members they are affiliated with via the consortia manager.
+* **Consortium manager: Can view existing settings.** This permission allows a user to view all the settings of members they are affiliated with via the consortium manager.
 * **Inventory: Share local instance with consortium.** This permission allows a user to share local instance records with consortium members.
 
 

--- a/content/en/docs/Platform essentials/Permissions/_index.md
+++ b/content/en/docs/Platform essentials/Permissions/_index.md
@@ -130,9 +130,9 @@ After confirming you will automatically be taken to the new/duplicate role.
 ![image](role-duplication-2.png)
 
 ## Shared Roles
-Shared roles are centrally managed in that they can only be edited in the consortia manager. A shared role will appear as a Role in all tenants with the same capabilities. User from the given tenant can be assigned to that role. Editing that role in the central tenant will change it for all tenants. 
+Shared roles are centrally managed in that they can only be edited in the Consortium manager. A shared role will appear as a Role in all tenants with the same capabilities. User from the given tenant can be assigned to that role. Editing that role in the central tenant will change it for all tenants.
 
-To share a role users must have permissions to access the consortia manager app and share data. With your active affiliation set to the systems central tenant. Navigate to Consortia manager -> Authorization Roles. 
+To share a role users must have permissions to access the Consortium manager app and share data. With your active affiliation set to the systems central tenant. Navigate to Consortium manager -> Authorization Roles.
 
 ![image](shared-roles-1.png)
 
@@ -154,7 +154,7 @@ Role assignments can be maanged from a few different places. Which place is most
 	* This is a good choice when assigning or unassigning multiple users to/from a given role 
 * From the Users app
 	* This is a good choice when managing role assignments for a given user
-* From Consortia manager -> Authorization Roles (only applicable to consortia with ECS enabled) 
+* From Consortium manager -> Authorization Roles (only applicable to consortia with ECS enabled)
 	* From here you can manage role assignments across all related tenants 
 	* From here you can also create "Shared" roles that can be used by all tenants in the system  
 

--- a/content/en/docs/Settings/Settings_Authorization-roles/Settings_Authorization-roles.md
+++ b/content/en/docs/Settings/Settings_Authorization-roles/Settings_Authorization-roles.md
@@ -74,7 +74,7 @@ To create an **Authorization role**, follow the steps outlined in [Role Creation
 
 ## Assign or unassign an Authorization role
 
-Management of role assignments can be done in several FOLIO applications: Settings \> Authorization roles, Users, or Consortia manager. See [Managing Role Assignments](https://folio-org.atlassian.net/wiki/spaces/UM/pages/789807108/Roles+Management+with+Eureka#Managing-Role-Assignments) for more information.
+Management of role assignments can be done in several FOLIO applications: Settings \> Authorization roles, Users, or Consortium manager. See [Managing Role Assignments](https://folio-org.atlassian.net/wiki/spaces/UM/pages/789807108/Roles+Management+with+Eureka#Managing-Role-Assignments) for more information.
 
 ## Edit an Authorization role
 


### PR DESCRIPTION
The app is officially named “Consortium manager” today.

(cherry picked from commit 7c060aeb10a9ddf6705d7cc0974727e11c33b182)